### PR TITLE
Fix GitHub workflow: remove npm dependencies

### DIFF
--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -20,10 +20,6 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: '18'
-        cache: 'npm'
-        
-    - name: Install dependencies
-      run: npm ci
       
     - name: Create production build
       run: |


### PR DESCRIPTION
- Removed npm ci step since this Chrome extension doesn't use npm packages
- Removed npm cache configuration
- Workflow now builds extension directly without dependency installation